### PR TITLE
Corrected command for updateassemblyinfo

### DIFF
--- a/Docs.Site/Docs/Reference/Build-Services.markdown
+++ b/Docs.Site/Docs/Reference/Build-Services.markdown
@@ -377,7 +377,7 @@ Running ```GitVersion /output buildserver``` will cause MyGet Build Services to 
 	GitVersion.NuGetVersion=3.0.23
 
 <p class="alert alert-info">
-    <strong>Note:</strong> If you require the <code>AssemblyInfo.cs</code> files in your project to be patched with the information from GitVersion, you will have to run it manually, for example using the command <code>call %GitVersion% /updateassemblyinfo</code>.
+    <strong>Note:</strong> If you require the <code>AssemblyInfo.cs</code> files in your project to be patched with the information from GitVersion, you will have to run it manually, for example using the command <code>call %GitVersion% /updateassemblyinfo true</code>.
 </p>
 
 ## Configuring Projects to Build


### PR DESCRIPTION
As per here:

https://github.com/ParticularLabs/GitVersion/wiki/Command-Line-Tool#directly-on-build-server

```
/updateassemblyinfo
```

By itself, won't work.  Since there is now an expectation that there will be a parameter passed in, either indicating that it should happen, i.e. **true** or providing a relative or absolute path to a CommonAssemblyInfo file
