### PR TITLE
Quick command for symbols publishing was incorrect

### DIFF
--- a/Docs.Site/Docs/Reference/Symbols.markdown
+++ b/Docs.Site/Docs/Reference/Symbols.markdown
@@ -61,7 +61,7 @@ Here's a quick cheatsheet of the commands related to symbol feeds:
 
 * Pushing a symbols package to MyGet:
 
-	```nuget.exe push <package-file> <myget-key> -Source https://www.myget.org/F/<feed-name>/api/v2/package```
+	```nuget.exe push <package-file> <myget-key> -Source https://www.myget.org/F/<feed-name>/symbols/api/v2/package```
 
 ## Troubleshooting
 


### PR DESCRIPTION
The URL specified in the quick command for symbols publishing was incorrect.  Fixed to be consistent with other documentation on the page and MyGet UI screens.