### PR TITLE
Incorrect symbols package publish url

### DIFF
--- a/Docs.Site/Docs/Reference/Feed-endpoints.markdown
+++ b/Docs.Site/Docs/Reference/Feed-endpoints.markdown
@@ -88,7 +88,7 @@ The following table lists which endpoint can be used with which client:
 
 MyGet has the following endpoints available for symbol server (debugging in Visual Studio and WinDbg):
 
-* /F/&lt;your-feed-name&gt;/api/v2/package - the symbols package publish endpoint
+* /F/&lt;your-feed-name&gt;/symbols/api/v2/package - the symbols package publish endpoint
 * /F/&lt;your-feed-name&gt;/symbols - the symbol server endpoint
 
 ### Npm-compatible feed endpoints


### PR DESCRIPTION
The symbols package publish api url is missing /symbols/ in the url example under Symbol server endpoint section.